### PR TITLE
chore: update `run_service.sh` script to use `v0.6.6`

### DIFF
--- a/run_service.sh
+++ b/run_service.sh
@@ -256,7 +256,7 @@ fi
 directory="trader"
 # This is a tested version that works well.
 # Feel free to replace this with a different version of the repo, but be careful as there might be breaking changes
-service_version="v0.6.5"
+service_version="v0.6.6"
 service_repo=https://github.com/valory-xyz/$directory.git
 if [ -d $directory ]
 then


### PR DESCRIPTION
This PR adds support for using `trader@v0.6.6`.