### PR TITLE
Implements RPC checks

### DIFF
--- a/run_service.sh
+++ b/run_service.sh
@@ -422,38 +422,43 @@ try_read_storage
 # Prompt for RPC
 [[ -z "${rpc}" ]] && read -rsp "Enter a Gnosis RPC that supports eth_newFilter [hidden input]: " rpc && echo || rpc="${rpc}"
 
-# Check if RPC out of requests
-out_of_requests=$(curl -s -S -X POST \
-  -H "Content-Type: application/json" \
-  --data '{"jsonrpc":"2.0","method":"eth_newFilter","params":["invalid"],"id":1}' "$rpc" | \
-  $PYTHON_CMD -c "import sys, json; print(json.load(sys.stdin)['error']['message']=='Out of requests')")
+# Check the RPC
+echo "Checking the provided RCP..."
 
-if [ "$out_of_requests" = True ]
-then
-    echo "The given RPC ($rpc) does not have any requests left! Terminating script..."
-    exit 1
-fi
-
-# Check if eth_newFilter is supported
-echo "Checking if the RPC supports 'eth_newFilter'..."
-response=$(curl -s -S -X POST \
+rcp_response=$(curl -s -S -X POST \
   -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"eth_newFilter","params":["invalid"],"id":1}' "$rpc")
 
-new_filter_supported=$(echo "$response" | \
+rcp_error_message=$(echo "$rcp_response" | \
 $PYTHON_CMD -c "import sys, json;
-try: print(json.load(sys.stdin)['error']['message']!='The method eth_newFilter does not exist/is not available')
-except Exception as e: print('False')")
+try: print(json.load(sys.stdin)['error']['message'])
+except Exception as e: print('Exception processing RCP response')")
 
-if [ "$new_filter_supported" != "True" ]; then
-    echo "Error: Either the provided RPC does not support 'eth_newFilter' or the received response is malformed. Please verify the RPC behavior."
+rcp_exception=$([[ "$rcp_error_message" == "Exception processing RCP response" ]] && echo true || echo false)
+if [ "$rcp_exception" = true ]; then
+    echo "Error: The received RCP response is malformed. Please verify the RPC address and/or RCP behavior."
     echo "  Received response:"
-    echo "  $response"
+    echo "  $rcp_response"
+    echo ""
     echo "Terminating script."
     exit 1
 fi
 
-echo "The provided RPC supports 'eth_newFilter'."
+rcp_out_of_requests=$([[ "$rcp_error_message" == "Out of requests" ]] && echo true || echo false)
+if [ "$rcp_out_of_requests" = true ]; then
+    echo "Error: The provided RCP is out of requests."
+    echo "Terminating script."
+    exit 1
+fi
+
+rcp_new_filter_supported=$([[ "$rcp_error_message" == "The method eth_newFilter does not exist/is not available" ]] && echo false || echo true)
+if [ "$rcp_new_filter_supported" = false ]; then
+    echo "Error: The provided RPC does not support 'eth_newFilter'."
+    echo "Terminating script."
+    exit 1
+fi
+
+echo "RPC checks passed."
 echo ""
 
 # clone repo

--- a/run_service.sh
+++ b/run_service.sh
@@ -430,11 +430,14 @@ response=$(curl -s -S -X POST \
 
 new_filter_supported=$(echo "$response" | \
 $PYTHON_CMD -c "import sys, json;
-try: response = sys.stdin.read().strip(); print(json.load(input_data)['error']['message']!='The method eth_newFilter does not exist/is not available')
-except Exception as e: print(f'Error: The provided RPC response is malformed or unexpected (response=\"{response}\"). Please verify the RPC behavior. Terminating script.')")
+try: print(json.load(sys.stdin)['error']['message']!='The method eth_newFilter does not exist/is not available')
+except Exception as e: print('False')")
 
 if [ "$new_filter_supported" = False ]; then
-    echo "Error: The provided RPC does not support 'eth_newFilter'. Terminating script."
+    echo "Error: Either the provided RPC does not support 'eth_newFilter' or the received response is malformed. Please verify the RPC behavior."
+    echo "  Received response:"
+    echo "  $response"
+    echo "Terminating script."
     exit 1
 fi
 

--- a/run_service.sh
+++ b/run_service.sh
@@ -433,7 +433,7 @@ $PYTHON_CMD -c "import sys, json;
 try: print(json.load(sys.stdin)['error']['message']!='The method eth_newFilter does not exist/is not available')
 except Exception as e: print('False')")
 
-if [ "$new_filter_supported" = False ]; then
+if [ "$new_filter_supported" != "True" ]; then
     echo "Error: Either the provided RPC does not support 'eth_newFilter' or the received response is malformed. Please verify the RPC behavior."
     echo "  Received response:"
     echo "  $response"


### PR DESCRIPTION
Implements/fixes several RCP checks and displays an informative message rather than launching a Python exception.
* Checks for malformed RCP responses
* Checks for RCP out of calls
* Rearranges RCP check for eth_newFilter

Addresses issue #81
Merges user contribution #83 