### PR TITLE
Fix on-chain agent IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ensure your machine satisfies the requirements:
 - You need xDAI on Gnosis Chain in one of your wallets.
 - You need an RPC for your agent instance. We recommend [QuickNode](https://www.quicknode.com/chains/xdai).
 
-## Run the Script
+## Run the Service
 
 ### For Non-Stakers
 
@@ -25,6 +25,12 @@ Clone this repository locally and execute:
 ```bash
 chmod +x run_service.sh
 ./run_service.sh
+```
+
+Answer 'No' when prompted:
+
+```text
+Do you want to use staking in this service? (yes/no): n
 ```
 
 ### For Stakers
@@ -36,16 +42,17 @@ chmod +x run_service.sh
 
 Before you proceed, ensure you have at least 50 OLAS on Gnosis Chain. For more information on staking, checkout the following [blogpost](https://www.valory.xyz/post/s-e-everest).
 
-To run the script (with staking) execute:
-
-```bash 
-./run_service.sh --with-staking
-```
-
-Otherwise, run:
+Clone this repository locally and execute:
 
 ```bash
+chmod +x run_service.sh
 ./run_service.sh
+```
+
+Answer 'Yes' when prompted:
+
+```text
+Do you want to use staking in this service? (yes/no): y
 ```
 
 __Notes__: 

--- a/run_service.sh
+++ b/run_service.sh
@@ -310,9 +310,6 @@ create_storage() {
     prompt_use_staking
     touch "../$env_file_path"
     echo "USE_STAKING=$USE_STAKING" > "../$env_file_path"
-    AGENT_ID=14
-    echo "AGENT_ID"=$AGENT_ID >> "../$env_file_path"
-
 
     # Generate the RPC file
     echo -n "$rpc" > "../$rpc_path"
@@ -382,15 +379,6 @@ try_read_storage() {
         if [ -f "$service_id_path" ]; then
             service_id=$(cat $service_id_path)
         fi
-
-        # INFO: This is a fix to avoid corrupting already-created stores
-        if [ -z "$AGENT_ID" ] && [ "$USE_STAKING" = true ]; then
-            AGENT_ID=12
-        elif [ -z "$AGENT_ID" ]; then
-            AGENT_ID=14
-        fi
-        echo "AGENT_ID=$AGENT_ID" >> "$env_file_path"
-
     else
         first_run=true
     fi
@@ -566,6 +554,7 @@ export CUSTOM_SERVICE_REGISTRY_TOKEN_UTILITY_ADDRESS="0xa45E64d13A30a51b91ae0eb1
 export CUSTOM_GNOSIS_SAFE_PROXY_FACTORY_ADDRESS="0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE"
 export CUSTOM_GNOSIS_SAFE_SAME_ADDRESS_MULTISIG_ADDRESS="0x6e7f594f680f7aBad18b7a63de50F0FeE47dfD06"
 export CUSTOM_MULTISEND_ADDRESS="0x40A2aCCbd92BCA938b02010E17A5b8929b49130D"
+export AGENT_ID=12
 export MECH_AGENT_ADDRESS="0x77af31De935740567Cf4fF1986D04B2c964A786a"
 export WXDAI_ADDRESS="0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d"
 

--- a/run_service.sh
+++ b/run_service.sh
@@ -386,10 +386,11 @@ try_read_storage() {
         # INFO: This is a fix to avoid corrupting already-created stores
         if [ -z "$AGENT_ID" ] && [ "$USE_STAKING" = true ]; then
             AGENT_ID=12
+            echo "AGENT_ID=$AGENT_ID" >> "$env_file_path"
         elif [ -z "$AGENT_ID" ]; then
             AGENT_ID=14
+            echo "AGENT_ID=$AGENT_ID" >> "$env_file_path"
         fi
-        echo "AGENT_ID=$AGENT_ID" >> "$env_file_path"
 
     else
         first_run=true

--- a/run_service.sh
+++ b/run_service.sh
@@ -310,7 +310,14 @@ create_storage() {
     prompt_use_staking
     touch "../$env_file_path"
     echo "USE_STAKING=$USE_STAKING" > "../$env_file_path"
-    AGENT_ID=14
+
+    if [ "$USE_STAKING" = true ]; then
+        # New staking services use AGENT_ID=12 until end of Everest staking program
+        AGENT_ID=12
+    else
+        # New non-staking services use AGENT_ID=14
+        AGENT_ID=14
+    fi
     echo "AGENT_ID"=$AGENT_ID >> "../$env_file_path"
 
 
@@ -384,10 +391,14 @@ try_read_storage() {
         fi
 
         # INFO: This is a fix to avoid corrupting already-created stores
+        # If $AGENT_ID is not defined at this point, it means it is a service created
+        # before the AGENT_ID fix was implemented.
         if [ -z "$AGENT_ID" ] && [ "$USE_STAKING" = true ]; then
+            # Existing staking services use AGENT_ID=12
             AGENT_ID=12
             echo "AGENT_ID=$AGENT_ID" >> "$env_file_path"
         elif [ -z "$AGENT_ID" ]; then
+            # Existing non-staking services use AGENT_ID=14
             AGENT_ID=14
             echo "AGENT_ID=$AGENT_ID" >> "$env_file_path"
         fi

--- a/run_service.sh
+++ b/run_service.sh
@@ -310,6 +310,9 @@ create_storage() {
     prompt_use_staking
     touch "../$env_file_path"
     echo "USE_STAKING=$USE_STAKING" > "../$env_file_path"
+    AGENT_ID=14
+    echo "AGENT_ID"=$AGENT_ID >> "../$env_file_path"
+
 
     # Generate the RPC file
     echo -n "$rpc" > "../$rpc_path"
@@ -379,6 +382,15 @@ try_read_storage() {
         if [ -f "$service_id_path" ]; then
             service_id=$(cat $service_id_path)
         fi
+
+        # INFO: This is a fix to avoid corrupting already-created stores
+        if [ -z "$AGENT_ID" ] && [ "$USE_STAKING" = true ]; then
+            AGENT_ID=12
+        elif [ -z "$AGENT_ID" ]; then
+            AGENT_ID=14
+        fi
+        echo "AGENT_ID=$AGENT_ID" >> "$env_file_path"
+
     else
         first_run=true
     fi
@@ -554,7 +566,6 @@ export CUSTOM_SERVICE_REGISTRY_TOKEN_UTILITY_ADDRESS="0xa45E64d13A30a51b91ae0eb1
 export CUSTOM_GNOSIS_SAFE_PROXY_FACTORY_ADDRESS="0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE"
 export CUSTOM_GNOSIS_SAFE_SAME_ADDRESS_MULTISIG_ADDRESS="0x6e7f594f680f7aBad18b7a63de50F0FeE47dfD06"
 export CUSTOM_MULTISEND_ADDRESS="0x40A2aCCbd92BCA938b02010E17A5b8929b49130D"
-export AGENT_ID=12
 export MECH_AGENT_ADDRESS="0x77af31De935740567Cf4fF1986D04B2c964A786a"
 export WXDAI_ADDRESS="0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d"
 

--- a/run_service.sh
+++ b/run_service.sh
@@ -310,6 +310,9 @@ create_storage() {
     prompt_use_staking
     touch "../$env_file_path"
     echo "USE_STAKING=$USE_STAKING" > "../$env_file_path"
+    AGENT_ID=14
+    echo "AGENT_ID"=$AGENT_ID >> "../$env_file_path"
+
 
     # Generate the RPC file
     echo -n "$rpc" > "../$rpc_path"
@@ -376,7 +379,15 @@ try_read_storage() {
         rpc=$(cat $rpc_path)
         agent_address=$(cat $agent_address_path)
         operator_address=$(get_address "$operator_keys_file")
-        if [ -f "$service_id_pa=14
+        if [ -f "$service_id_path" ]; then
+            service_id=$(cat $service_id_path)
+        fi
+
+        # INFO: This is a fix to avoid corrupting already-created stores
+        if [ -z "$AGENT_ID" ] && [ "$USE_STAKING" = true ]; then
+            AGENT_ID=12
+        elif [ -z "$AGENT_ID" ]; then
+            AGENT_ID=14
         fi
         echo "AGENT_ID=$AGENT_ID" >> "$env_file_path"
 
@@ -551,8 +562,7 @@ export CUSTOM_SERVICE_MANAGER_ADDRESS="0x04b0007b2aFb398015B76e5f22993a1fddF8364
 export CUSTOM_SERVICE_REGISTRY_ADDRESS="0x9338b5153AE39BB89f50468E608eD9d764B755fD"
 export CUSTOM_STAKING_ADDRESS="0x5add592ce0a1B5DceCebB5Dcac086Cd9F9e3eA5C"
 export CUSTOM_OLAS_ADDRESS="0xcE11e14225575945b8E6Dc0D4F2dD4C570f79d9f"
-export Cexport AGENT_ID=12
-USTOM_SERVICE_REGISTRY_TOKEN_UTILITY_ADDRESS="0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8"
+export CUSTOM_SERVICE_REGISTRY_TOKEN_UTILITY_ADDRESS="0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8"
 export CUSTOM_GNOSIS_SAFE_PROXY_FACTORY_ADDRESS="0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE"
 export CUSTOM_GNOSIS_SAFE_SAME_ADDRESS_MULTISIG_ADDRESS="0x6e7f594f680f7aBad18b7a63de50F0FeE47dfD06"
 export CUSTOM_MULTISEND_ADDRESS="0x40A2aCCbd92BCA938b02010E17A5b8929b49130D"


### PR DESCRIPTION
Services without staking:
* Newly created services will use AGENT_ID=14
* Already created services will update AGENT_ID=12 -> AGENT_ID=14

Services with staking:
* Newly created services will use AGENT_ID=12
* Already created services will keep using AGENT_ID=12



Small improvements on README.md