### PR TITLE
Report script

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,18 @@ Agent runners are recommended to create a [backup](https://github.com/valory-xyz
     ```
 
     Or restrict the search to specific dates by defining the "from" and "to" dates:
+
     ```bash
     cd trader; poetry run python ../trades.py YOUR_SAFE_ADDRESS --from-date 2023-08-15:03:50:00 --to-date 2023-08-20:13:45:00; cd ..
     ```
 
-2. Use this command to investigate your agent's logs:
+2. Use the `report` command to display a summary of the service status:
+
+   ```bash
+   cd trader; poetry run python ../report.py; cd ..
+   ```
+
+3. Use this command to investigate your agent's logs:
 
     ```bash
     cd trader; poetry run autonomy analyse logs --from-dir trader_service/abci_build/persistent_data/logs/ --agent aea_0 --reset-db; cd ..

--- a/rank_traders.py
+++ b/rank_traders.py
@@ -305,6 +305,9 @@ if __name__ == "__main__":
     print("Starting script")
     user_args = _parse_args()
 
+    with open(trades.RPC_PATH, "r", encoding="utf-8") as rpc_file:
+        rpc = rpc_file.read()
+
     print("Querying Thegraph...")
     all_trades_json = _query_omen_xdai_subgraph(
         user_args.from_date.timestamp(),
@@ -323,7 +326,7 @@ if __name__ == "__main__":
     for i, (creator_id, trades_json_id) in enumerate(
         creator_to_trades.items(), start=1
     ):
-        _, statistics_table_id = trades.parse_user(creator_id, trades_json_id)
+        _, statistics_table_id = trades.parse_user(rpc, creator_id, trades_json_id, {})
         creator_to_statistics[creator_id] = statistics_table_id
         _print_progress_bar(i, total_traders)
 

--- a/report.py
+++ b/report.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2022-2023 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Obtains a report of the current service."""
+
+import datetime
+import json
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Any
+
+import docker
+import trades
+from trades import (
+    MarketAttribute,
+    MarketState,
+    get_balance,
+    get_token_balance,
+    wei_to_olas,
+    wei_to_unit,
+    wei_to_wxdai,
+    wei_to_xdai,
+)
+from web3 import HTTPProvider, Web3
+
+
+SCRIPT_PATH = Path(__file__).resolve().parent
+STORE_PATH = Path(SCRIPT_PATH, ".trader_runner")
+RPC_PATH = Path(STORE_PATH, "rpc.txt")
+AGENT_KEYS_JSON_PATH = Path(STORE_PATH, "keys.json")
+OPERATOR_KEYS_JSON_PATH = Path(STORE_PATH, "operator_keys.json")
+SAFE_ADDRESS_PATH = Path(STORE_PATH, "service_safe_address.txt")
+SERVICE_ID_PATH = Path(STORE_PATH, "service_id.txt")
+SERVICE_STAKING_TOKEN_JSON_PATH = Path(
+    SCRIPT_PATH,
+    "trader",
+    "packages",
+    "valory",
+    "contracts",
+    "service_staking_token",
+    "build",
+    "ServiceStakingToken.json",
+)
+STAKING_CONTRACT_ADDRESS = "0x5add592ce0a1B5DceCebB5Dcac086Cd9F9e3eA5C"
+
+SAFE_BALANCE_THRESHOLD = 500000000000000000
+AGENT_BALANCE_THRESHOLD = 50000000000000000
+OPERATOR_BALANCE_THRESHOLD = 50000000000000000
+
+OUTPUT_WIDTH = 80
+
+
+def _print_section_header(header: str) -> None:
+    print("\n" + header)
+    print("—" * OUTPUT_WIDTH)
+
+
+def _print_subsection_header(header: str) -> None:
+    print("\n" + header)
+    print("=" * OUTPUT_WIDTH)
+
+
+def _print_status(key: str, value: str, message: str = None) -> None:
+    print(f"{key:<30}{value:<10} {message or ''}")
+
+
+def _warning_message(current_value: int, threshold: int = 0, message: str = "") -> str:
+    default_message = (
+        f"\033[93m- Balance too low. Threshold is {wei_to_unit(threshold):.2f}.\033[0m"
+    )
+    if current_value < threshold:
+        return f"\033[93m- {message}\033[0m" if message else default_message
+    return ""
+
+
+def _get_agent_status() -> str:
+    client = docker.from_env()
+    trader_abci_container = (
+        client.containers.get("trader_abci_0")
+        if "trader_abci_0" in [c.name for c in client.containers.list()]
+        else None
+    )
+    trader_tm_container = (
+        client.containers.get("trader_tm_0")
+        if "trader_tm_0" in [c.name for c in client.containers.list()]
+        else None
+    )
+
+    if trader_abci_container and trader_tm_container:
+        return "Running"
+    else:
+        return "Not Running"
+
+
+def _parse_args() -> Any:
+    """Parse the script arguments."""
+    parser = ArgumentParser(description="Get a report for a trader service.")
+
+
+if __name__ == "__main__":
+    user_args = _parse_args()
+
+    with open(AGENT_KEYS_JSON_PATH, "r", encoding="utf-8") as file:
+        agent_keys_data = json.load(file)
+    agent_address = agent_keys_data[0]["address"]
+
+    with open(OPERATOR_KEYS_JSON_PATH, "r", encoding="utf-8") as file:
+        operator_keys_data = json.load(file)
+    operator_address = operator_keys_data[0]["address"]
+
+    with open(SAFE_ADDRESS_PATH, "r", encoding="utf-8") as file:
+        safe_address = file.read().strip()
+
+    with open(SERVICE_ID_PATH, "r", encoding="utf-8") as file:
+        service_id = int(file.read().strip())
+
+    with open(RPC_PATH, "r", encoding="utf-8") as file:
+        rpc = file.read().strip()
+
+    # Prediction market trading
+    mech_requests = trades.get_mech_requests(rpc, safe_address)
+    mech_statistics = trades._get_mech_statistics(mech_requests)
+    trades_json = trades._query_omen_xdai_subgraph(safe_address)
+    _, statistics_table = trades.parse_user(
+        rpc, safe_address, trades_json, mech_statistics
+    )
+
+    print("")
+    print("==============")
+    print("Service report")
+    print("==============")
+    print("")
+
+    # Performance
+    _print_section_header("Performance")
+    _print_subsection_header("Staking")
+
+    is_staked = False
+    try:
+        w3 = Web3(HTTPProvider(rpc))
+        with open(SERVICE_STAKING_TOKEN_JSON_PATH, "r", encoding="utf-8") as file:
+            contract_data = json.load(file)
+
+        abi = contract_data.get("abi", [])
+        contract_instance = w3.eth.contract(address=STAKING_CONTRACT_ADDRESS, abi=abi)
+        is_staked = contract_instance.functions.isServiceStaked(service_id).call()
+        _print_status("Is service staked?", f"{is_staked}")
+
+        if is_staked:
+            service_info = contract_instance.functions.mapServiceInfo(service_id).call()
+            ts_start = service_info[2]
+            rewards = service_info[3]
+            staked_utc_datetime = datetime.datetime.utcfromtimestamp(ts_start).replace(
+                tzinfo=datetime.timezone.utc
+            )
+            staked_utc_string = staked_utc_datetime.strftime("%Y-%m-%d %H:%M:%S UTC")
+            _print_status("Staked at", f"{staked_utc_string}")
+            _print_status("Accrued rewards", f"{wei_to_olas(rewards)}")
+
+            next_reward_checkpoint_ts = (
+                contract_instance.functions.getNextRewardCheckpointTimestamp().call()
+            )
+            next_reward_utc_datetime = datetime.datetime.utcfromtimestamp(
+                next_reward_checkpoint_ts
+            ).replace(tzinfo=datetime.timezone.utc)
+            next_reward_utc_string = next_reward_utc_datetime.strftime(
+                "%Y-%m-%d %H:%M:%S UTC"
+            )
+            _print_status("Next rewards checkpoint", f"{next_reward_utc_string}")
+
+            # TODO
+            # Staked OLAS 25 too low – threshold is 50
+            # Number of txns this epoch	4 too low – threshold is 10
+            # Accrued OLAS rewards 1
+
+    except Exception:
+        print("An error occurred while interacting with the staking contract.")
+
+    _print_subsection_header(f"Prediction market trading")
+    _print_status(
+        "ROI closed markets",
+        f"{statistics_table[MarketAttribute.ROI][MarketState.CLOSED]*100.0:.2f} %",
+    )
+    _print_status(
+        "ROI total", f"{statistics_table[MarketAttribute.ROI]['TOTAL']*100.0:.2f} %"
+    )
+
+    # TODO
+    # 3d participation/market 100%
+
+    # Service
+    _print_section_header("Service")
+    _print_status("ID", service_id)
+
+    # Agent
+    agent_status = _get_agent_status()
+    agent_xdai = get_balance(agent_address, rpc)
+    agent_wxdai = get_token_balance(agent_address, trades.WXDAI_CONTRACT_ADDRESS, rpc)
+    _print_subsection_header(
+        f"Agent {_warning_message(agent_xdai + agent_wxdai, SAFE_BALANCE_THRESHOLD)}"
+    )
+    _print_status("Status", agent_status)
+    _print_status("Address", agent_address)
+    _print_status("xDAI Balance", wei_to_xdai(agent_xdai))
+    _print_status("WxDAI Balance", wei_to_xdai(agent_wxdai))
+
+    # Safe
+    safe_xdai = get_balance(safe_address, rpc)
+    safe_wxdai = get_token_balance(safe_address, trades.WXDAI_CONTRACT_ADDRESS, rpc)
+    _print_subsection_header(
+        f"Safe {_warning_message(safe_xdai + safe_wxdai, SAFE_BALANCE_THRESHOLD)}"
+    )
+    _print_status("Address", safe_address)
+    _print_status("xDAI Balance", wei_to_xdai(safe_xdai))
+    _print_status("WxDAI Balance", wei_to_wxdai(safe_wxdai))
+
+    # Owner/Operator
+    operator_xdai = get_balance(operator_address, rpc)
+    operator_wxdai = get_token_balance(
+        operator_address, trades.WXDAI_CONTRACT_ADDRESS, rpc
+    )
+    _print_subsection_header(
+        f"Owner/Operator {_warning_message(operator_xdai + operator_wxdai, SAFE_BALANCE_THRESHOLD)}"
+    )
+    _print_status("Address", operator_address)
+    _print_status("xDAI Balance", wei_to_xdai(operator_xdai))
+    _print_status("WxDAI Balance", wei_to_xdai(operator_wxdai))
+    print("")

--- a/report.py
+++ b/report.py
@@ -66,6 +66,12 @@ OPERATOR_BALANCE_THRESHOLD = 50000000000000000
 
 OUTPUT_WIDTH = 80
 
+class TerminalColors:
+    GREEN = "\033[92m"
+    RED = "\033[91m"
+    YELLOW = "\033[93m"
+    RESET = "\033[0m"
+
 
 def _print_section_header(header: str) -> None:
     print("\n" + header)
@@ -83,10 +89,10 @@ def _print_status(key: str, value: str, message: str = None) -> None:
 
 def _warning_message(current_value: int, threshold: int = 0, message: str = "") -> str:
     default_message = (
-        f"\033[93m- Balance too low. Threshold is {wei_to_unit(threshold):.2f}.\033[0m"
+        f"{TerminalColors.YELLOW}- Balance too low. Threshold is {wei_to_unit(threshold):.2f}.{TerminalColors.RESET}"
     )
     if current_value < threshold:
-        return f"\033[93m- {message}\033[0m" if message else default_message
+        return f"{TerminalColors.YELLOW}- {message}{TerminalColors.RESET}" if message else default_message
     return ""
 
 
@@ -104,9 +110,9 @@ def _get_agent_status() -> str:
     )
 
     if trader_abci_container and trader_tm_container:
-        return "Running"
+        return f"{TerminalColors.GREEN}Running{TerminalColors.RESET}"
     else:
-        return "Not Running"
+        return f"{TerminalColors.RED}Not Running{TerminalColors.RESET}"
 
 
 def _parse_args() -> Any:

--- a/report.py
+++ b/report.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 import json
 from argparse import ArgumentParser
 from pathlib import Path
+import time
 from typing import Any
 
 import docker
@@ -61,10 +62,13 @@ SERVICE_STAKING_TOKEN_JSON_PATH = Path(
 STAKING_CONTRACT_ADDRESS = "0x5add592ce0a1B5DceCebB5Dcac086Cd9F9e3eA5C"
 
 SAFE_BALANCE_THRESHOLD = 500000000000000000
-AGENT_BALANCE_THRESHOLD = 50000000000000000
-OPERATOR_BALANCE_THRESHOLD = 50000000000000000
+AGENT_XDAI_BALANCE_THRESHOLD = 50000000000000000
+OPERATOR_XDAI_BALANCE_THRESHOLD = 50000000000000000
+MECH_REQUESTS_PER_EPOCH_THRESHOLD = 10
+TRADES_LOOKBACK_DAYS = 3
 
 OUTPUT_WIDTH = 80
+
 
 class ColorCode:
     GREEN = "\033[92m"
@@ -77,10 +81,27 @@ def _color_string(text: str, color_code: str) -> str:
     return f"{color_code}{text}{ColorCode.RESET}"
 
 
-def _color_boolean(is_true: bool, true_string: str="True", false_string: str="False") -> str:
+def _color_bool(
+    is_true: bool, true_string: str = "True", false_string: str = "False"
+) -> str:
     if is_true:
         return _color_string(true_string, ColorCode.GREEN)
     return _color_string(false_string, ColorCode.RED)
+
+
+def _color_percent(p: float, multiplier: float = 100, symbol: str = "%") -> str:
+    if p >= 0:
+        return f"{p*multiplier:.2f} {symbol}"
+    return _color_string(f"{p*multiplier:.2f} {symbol}", ColorCode.RED)
+
+
+def _trades_since_message(trades_json: dict[str, Any], utc_ts: float = 0) -> str:
+    filtered_trades = [trade for trade in trades_json.get("data", {}).get("fpmmTrades", []) if float(trade["creationTimestamp"]) >= utc_ts]
+    unique_markets = set(trade["fpmm"]["id"] for trade in filtered_trades)
+    trades_count = len(filtered_trades)
+    markets_count = len(unique_markets)
+    return f"{trades_count} trades on {markets_count} markets"
+
 
 def _print_section_header(header: str) -> None:
     print("\n\n" + header)
@@ -97,11 +118,16 @@ def _print_status(key: str, value: str, message: str = "") -> None:
 
 
 def _warning_message(current_value: int, threshold: int = 0, message: str = "") -> str:
-    default_message = (
-        _color_string(f"- Balance too low. Threshold is {wei_to_unit(threshold):.2f}.", ColorCode.YELLOW)
+    default_message = _color_string(
+        f"- Too low. Threshold is {wei_to_unit(threshold):.2f}.",
+        ColorCode.YELLOW,
     )
     if current_value < threshold:
-        return _color_string(f"- {message}", ColorCode.YELLOW) if message else default_message
+        return (
+            _color_string(f"- {message}", ColorCode.YELLOW)
+            if message
+            else default_message
+        )
     return ""
 
 
@@ -119,18 +145,8 @@ def _get_agent_status() -> str:
     )
 
     is_running = trader_abci_container and trader_tm_container
-    return _color_boolean(is_running, "Running", "Stopped")
+    return _color_bool(is_running, "Running", "Stopped")
 
-def _format_time_difference(utc_ts_1: float, utc_ts_2: float) -> str:
-    seconds = abs(utc_ts_2 - utc_ts_1)
-    days, seconds = divmod(seconds, 86400)
-    hours, seconds = divmod(seconds, 3600)
-    minutes, _ = divmod(seconds, 60)
-
-    if days >= 1:
-        return f"{int(days)}d {int(hours):02}:{int(minutes):02}h"
-    else:
-        return f"{int(hours):02}:{int(minutes):02}h"
 
 def _parse_args() -> Any:
     """Parse the script arguments."""
@@ -158,7 +174,8 @@ if __name__ == "__main__":
         rpc = file.read().strip()
 
     # Prediction market trading
-    mech_requests = trades.get_mech_requests(rpc, safe_address)
+    # mech_requests = trades.get_mech_requests(rpc, safe_address)
+    mech_requests = {}
     mech_statistics = trades._get_mech_statistics(mech_requests)
     trades_json = trades._query_omen_xdai_subgraph(safe_address)
     _, statistics_table = trades.parse_user(
@@ -182,53 +199,33 @@ if __name__ == "__main__":
         abi = contract_data.get("abi", [])
         contract_instance = w3.eth.contract(address=STAKING_CONTRACT_ADDRESS, abi=abi)
         is_staked = contract_instance.functions.isServiceStaked(service_id).call()
-        _print_status("Is service staked?", _color_boolean(is_staked, "Yes", "No"))
+        _print_status("Is service staked?", _color_bool(is_staked, "Yes", "No"))
 
         if is_staked:
-            current_utc_ts = datetime.utcnow().timestamp()
+            _print_status("Staked (security deposit)", f"{wei_to_olas(0)}")
+            _print_status("Staked (slashable bond)", f"{wei_to_olas(0)}")
 
             service_info = contract_instance.functions.mapServiceInfo(service_id).call()
-            ts_start = service_info[2]
             rewards = service_info[3]
-            staked_utc_datetime = datetime.utcfromtimestamp(ts_start).replace(
-                tzinfo=timezone.utc
-            )
-            staked_utc_string = staked_utc_datetime.strftime("%Y-%m-%d %H:%M:%S UTC")
-            staked_interval_string = _format_time_difference(ts_start, current_utc_ts)
-            _print_status("Staked at", f"{staked_utc_string} ({staked_interval_string} ago)")
             _print_status("Accrued rewards", f"{wei_to_olas(rewards)}")
 
-            next_reward_checkpoint_ts = (
-                contract_instance.functions.getNextRewardCheckpointTimestamp().call()
-            )
-            next_reward_utc_datetime = datetime.utcfromtimestamp(
-                next_reward_checkpoint_ts
-            ).replace(tzinfo=timezone.utc)
-            next_reward_utc_string = next_reward_utc_datetime.strftime(
-                "%Y-%m-%d %H:%M:%S UTC"
-            )
-            remaining_time_string = _format_time_difference(current_utc_ts, next_reward_checkpoint_ts)
-            _print_status("Next rewards checkpoint", f"{next_reward_utc_string} ({remaining_time_string} remaining)")
-
-            # TODO
-            # Staked OLAS 25 too low – threshold is 50
-            # Number of txns this epoch	4 too low – threshold is 10
-            # Accrued OLAS rewards 1
+            mech_requests_current_epoch = 0
+            _print_status("Num. Mech txs current epoch", f"{mech_requests_current_epoch} {_warning_message(mech_requests_current_epoch, MECH_REQUESTS_PER_EPOCH_THRESHOLD)}")
 
     except Exception:
         print("An error occurred while interacting with the staking contract.")
 
     _print_subsection_header(f"Prediction market trading")
     _print_status(
-        "ROI closed markets",
-        f"{statistics_table[MarketAttribute.ROI][MarketState.CLOSED]*100.0:.2f} %",
-    )
-    _print_status(
-        "ROI total", f"{statistics_table[MarketAttribute.ROI]['TOTAL']*100.0:.2f} %"
+        "ROI on closed markets",
+        _color_percent(statistics_table[MarketAttribute.ROI][MarketState.CLOSED]),
     )
 
-    # TODO
-    # 3d participation/market 100%
+    since_ts = time.time() - 60*60*24 * TRADES_LOOKBACK_DAYS
+    _print_status(
+        f"Trades on last {TRADES_LOOKBACK_DAYS} days",
+        _trades_since_message(trades_json, since_ts),
+    )
 
     # Service
     _print_section_header("Service")
@@ -237,14 +234,13 @@ if __name__ == "__main__":
     # Agent
     agent_status = _get_agent_status()
     agent_xdai = get_balance(agent_address, rpc)
-    agent_wxdai = get_token_balance(agent_address, trades.WXDAI_CONTRACT_ADDRESS, rpc)
-    _print_subsection_header(
-        f"Agent {_warning_message(agent_xdai + agent_wxdai, SAFE_BALANCE_THRESHOLD)}"
-    )
+    _print_subsection_header(f"Agent")
     _print_status("Status", agent_status)
     _print_status("Address", agent_address)
-    _print_status("xDAI Balance", wei_to_xdai(agent_xdai))
-    _print_status("WxDAI Balance", wei_to_xdai(agent_wxdai))
+    _print_status(
+        "xDAI Balance",
+        f"{wei_to_xdai(agent_xdai)} {_warning_message(agent_xdai, AGENT_XDAI_BALANCE_THRESHOLD)}",
+    )
 
     # Safe
     safe_xdai = get_balance(safe_address, rpc)
@@ -258,13 +254,10 @@ if __name__ == "__main__":
 
     # Owner/Operator
     operator_xdai = get_balance(operator_address, rpc)
-    operator_wxdai = get_token_balance(
-        operator_address, trades.WXDAI_CONTRACT_ADDRESS, rpc
-    )
-    _print_subsection_header(
-        f"Owner/Operator {_warning_message(operator_xdai + operator_wxdai, SAFE_BALANCE_THRESHOLD)}"
-    )
+    _print_subsection_header(f"Owner/Operator")
     _print_status("Address", operator_address)
-    _print_status("xDAI Balance", wei_to_xdai(operator_xdai))
-    _print_status("WxDAI Balance", wei_to_xdai(operator_wxdai))
+    _print_status(
+        "xDAI Balance",
+        f"{wei_to_xdai(operator_xdai)} {_warning_message(operator_xdai, OPERATOR_XDAI_BALANCE_THRESHOLD)}",
+    )
     print("")

--- a/trades.py
+++ b/trades.py
@@ -312,7 +312,7 @@ def _query_omen_xdai_subgraph(  # pylint: disable=too-many-locals
     from_timestamp: float = DEFAULT_FROM_TIMESTAMP,
     to_timestamp: float = DEFAULT_TO_TIMESTAMP,
     fpmm_from_timestamp: float = DEFAULT_FROM_TIMESTAMP,
-    fpmm_to_timestamp: float = DEFAULT_TO_TIMESTAMP
+    fpmm_to_timestamp: float = DEFAULT_TO_TIMESTAMP,
 ) -> dict[str, Any]:
     """Query the subgraph."""
     url = "https://api.thegraph.com/subgraphs/name/protofire/omen-xdai"
@@ -748,7 +748,9 @@ def parse_user(  # pylint: disable=too-many-locals,too-many-statements
     return output, statistics_table
 
 
-def _get_mech_statistics(mech_requests: Dict[str, Any]) -> Dict[str, Dict[str, int]]:
+def get_mech_statistics(mech_requests: Dict[str, Any]) -> Dict[str, Dict[str, int]]:
+    """Outputs a table with Mech statistics"""
+
     mech_statistics: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
 
     for mech_request in mech_requests.values():
@@ -778,7 +780,7 @@ if __name__ == "__main__":
         rpc = rpc_file.read()
 
     mech_requests = get_mech_requests(rpc, user_args.creator)
-    mech_statistics = _get_mech_statistics(mech_requests)
+    mech_statistics = get_mech_statistics(mech_requests)
 
     trades_json = _query_omen_xdai_subgraph(
         user_args.creator,


### PR DESCRIPTION
Implements a report script to have a quick healthcheck on service status and staking state.

To call the script, from the trader-quickstart main folder:
`cd trader; poetry run python ../report.py; cd ..`

A number of other scripts needed to be modified in order to accomodate the changes required by this script.

Also, the following improvement has been implemented in this PR: #127 
