### PR TITLE
chore: bump to `trader@v0.10.1`

### DIFF
--- a/run_service.sh
+++ b/run_service.sh
@@ -545,7 +545,7 @@ directory="trader"
 service_repo=https://github.com/$org_name/$directory.git
 # This is a tested version that works well.
 # Feel free to replace this with a different version of the repo, but be careful as there might be breaking changes
-service_version="v0.10.0"
+service_version="v0.10.1"
 
 echo ""
 echo "---------------"


### PR DESCRIPTION
This PR bumps the trader-quickstart to v0.10.1.