### PR TITLE
Fix retries (and update trader version)

### DIFF
--- a/run_service.sh
+++ b/run_service.sh
@@ -557,7 +557,7 @@ directory="trader"
 service_repo=https://github.com/$org_name/$directory.git
 # This is a tested version that works well.
 # Feel free to replace this with a different version of the repo, but be careful as there might be breaking changes
-service_version="v0.11.6"
+service_version="v0.11.7"
 
 # Define constants for on-chain interaction
 export RPC_RETRIES=40


### PR DESCRIPTION
Fix retries

- Increased retry timeout to 120 seconds
- Increased retries to 40 (ample margin, not reached usually)
- Fixed https://github.com/valory-xyz/trader-quickstart/issues/98. This fix was required to stop capturing output in useless variable, in order to allow seeing log messages comming from the framework.
- Updated trader version

NOTE: Needs a trader version which integrates these changes from Open Autonomy: https://github.com/valory-xyz/open-autonomy/pull/2140