### PR TITLE
Also account for the redeemed invalid markets

### DIFF
--- a/trades.py
+++ b/trades.py
@@ -720,6 +720,15 @@ def parse_user(  # pylint: disable=too-many-locals,too-many-statements
                     earnings = collateral_amount
                     output += "  Final answer: Market has been declared invalid.\n"
                     output += f"      Earnings: {wei_to_xdai(earnings)}\n"
+                    redeemed = _is_redeemed(user_json, fpmmTrade)
+                    if redeemed:
+                        statistics_table[MarketAttribute.NUM_REDEEMED][
+                            market_status
+                        ] += 1
+                        statistics_table[MarketAttribute.REDEMPTIONS][
+                            market_status
+                        ] += earnings
+
                 elif outcome_index == current_answer:
                     earnings = outcomes_tokens_traded
                     output += f"  Final answer: {fpmm['outcomes'][current_answer]!r} - Congrats! The trade was for the winner answer.\n"


### PR DESCRIPTION
Fixes the analysis of the `trades.py` script.

Previously, the script was increasing the calculated redeemed earnings:
https://github.com/valory-xyz/trader-quickstart/blob/b1dc67542804d53bde9fdea9645c035324a9d071/trades.py#L737

only when the market was not invalid:
https://github.com/valory-xyz/trader-quickstart/blob/b1dc67542804d53bde9fdea9645c035324a9d071/trades.py#L723

However, the calculated earnings were increased in both cases:
https://github.com/valory-xyz/trader-quickstart/blob/b1dc67542804d53bde9fdea9645c035324a9d071/trades.py#L742

Therefore, this was a mistake in the calculation. The code now also accounts for the redeemed invalid markets.

:information_source: As an additional note, the script appears to be missing separate rows for the invalid markets, which would enhance clarity.