### PR TITLE
Bump the trader to `v0.17.0`

### DIFF
--- a/run_service.sh
+++ b/run_service.sh
@@ -210,9 +210,9 @@ get_private_key() {
 
 # Function to warm start the policy
 warm_start() {
-    echo '["prediction-online", "prediction-online-sme", "prediction-online-summarized-info", "prediction-sentence-embedding-bold", "prediction-sentence-embedding-conservative"]' | sudo tee "$PWD/../$store/available_tools_store.json"  > /dev/null
-    echo '{"counts": [0,0,0,0,0], "eps": 0.1, "rewards": [0.0,0.0,0.0,0.0,0.0]}' | sudo tee "$PWD/../$store/policy_store.json"  > /dev/null
-    echo '{}' | sudo tee "$PWD/../$store/utilized_tools.json"  > /dev/null
+    echo '["prediction-online", "prediction-online-sme", "prediction-online-summarized-info", "prediction-sentence-embedding-bold", "prediction-sentence-embedding-conservative"]' | sudo tee "${path_to_store}available_tools_store.json"  > /dev/null
+    echo '{"counts": [0,0,0,0,0], "eps": 0.1, "rewards": [0.0,0.0,0.0,0.0,0.0]}' | sudo tee "${path_to_store}policy_store.json"  > /dev/null
+    echo '{}' | sudo tee "${path_to_store}utilized_tools.json"  > /dev/null
 }
 
 # Function to add a volume to a service in a Docker Compose file
@@ -463,6 +463,7 @@ dotenv_set_key() {
 
 
 store=".trader_runner"
+path_to_store="$PWD/$store/"
 env_file_path="$store/.env"
 rpc_path="$store/rpc.txt"
 operator_keys_file="$store/operator_keys.json"
@@ -1165,8 +1166,8 @@ cd ..
 # warm start is disabled as no global weights are provided to calibrate the tools' weights
 # warm_start
 
-add_volume_to_service "$PWD/trader_service/abci_build/docker-compose.yaml" "trader_abci_0" "/data" "$PWD/../$store/"
-sudo chown -R $(whoami) "$PWD/../$store/"
+add_volume_to_service "$PWD/trader_service/abci_build/docker-compose.yaml" "trader_abci_0" "/data" "$path_to_store"
+sudo chown -R $(whoami) "$path_to_store"
 
 # Run the deployment
 export OPEN_AUTONOMY_PRIVATE_KEY_PASSWORD="$password" && poetry run autonomy deploy run --build-dir "$directory" --detach

--- a/run_service.sh
+++ b/run_service.sh
@@ -614,7 +614,7 @@ directory="trader"
 service_repo=https://github.com/$org_name/$directory.git
 # This is a tested version that works well.
 # Feel free to replace this with a different version of the repo, but be careful as there might be breaking changes
-service_version="v0.16.5"
+service_version="v0.17.0"
 
 # Define constants for on-chain interaction
 gnosis_chain_id=100


### PR DESCRIPTION
Bumps the trader to `v0.17.0` and addresses the breaking changes.

Unfortunately getting lots of warnings after the update, due to https://github.com/paramiko/paramiko/issues/2419.