### PR TITLE
bump: trader@v0.17.2

### DIFF
--- a/run_service.sh
+++ b/run_service.sh
@@ -659,7 +659,7 @@ directory="trader"
 service_repo=https://github.com/$org_name/$directory.git
 # This is a tested version that works well.
 # Feel free to replace this with a different version of the repo, but be careful as there might be breaking changes
-service_version="v0.17.0"
+service_version="v0.17.1"
 
 # Define constants for on-chain interaction
 gnosis_chain_id=100

--- a/run_service.sh
+++ b/run_service.sh
@@ -659,7 +659,7 @@ directory="trader"
 service_repo=https://github.com/$org_name/$directory.git
 # This is a tested version that works well.
 # Feel free to replace this with a different version of the repo, but be careful as there might be breaking changes
-service_version="v0.17.1"
+service_version="v0.17.2"
 
 # Define constants for on-chain interaction
 gnosis_chain_id=100


### PR DESCRIPTION
This PR bumps the trader-quickstart to use `trader@v0.17.2`.