### PR TITLE
Fix export variables on MinGW

### DIFF
--- a/run_service.sh
+++ b/run_service.sh
@@ -503,10 +503,12 @@ dotenv_set_key() {
 export_dotenv() {
     local dotenv_path="$1"
     unamestr=$(uname)
-    if [ "$unamestr" = 'Linux' ]; then
-        export $(grep -v '^#' $dotenv_path | xargs -d '\n')
-    elif [ "$unamestr" = 'FreeBSD' ] || [ "$unamestr" = 'Darwin' ]; then
+    # Mac
+    if [ "$unamestr" = 'FreeBSD' ] || [ "$unamestr" = 'Darwin' ]; then
         export $(grep -v '^#' $dotenv_path | xargs -0)
+    # Linux, WSL, MinGW
+    else
+        export $(grep -v '^#' $dotenv_path | xargs -d '\n')
     fi
 }
 


### PR DESCRIPTION
Fix export variables on MinGW. This PR changes the way variables are exported.

A specific check is used for Mac. Rest of the systems (Linux, WSL2, MinGW) use the default mechanism. Note that WSL2 reports the same `uname` as Ubuntu (`Linux`), therefore it was not causing an issue there.