### PR TITLE
Fix: Not unstake when `--attended=false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Agent runners are recommended to create a [backup](https://github.com/valory-xyz
 ### Skip user prompts
 
 You can optionally pass `--attended=false` or export the environment variable `ATTENDED=false` to skip asking for inputs from the user.
-Note: In this case, if the service is staked then it will not update on-chain, to avoid unstaking.
+Note: In this case, if the service is staked, then it will not update the on-chain service, to avoid unstaking. If you choose a staking contract with different parameters (e.g., different bond), then you have to execute the attended mode of the script to update the on-chain service.
 
 ## Observe your agents
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Agent runners are recommended to create a [backup](https://github.com/valory-xyz
 ### Skip user prompts
 
 You can optionally pass `--attended=false` or export the environment variable `ATTENDED=false` to skip asking for inputs from the user.
+Note: In this case, if the service is staked then it will not update on-chain, to avoid unstaking.
 
 ## Observe your agents
 

--- a/run_service.sh
+++ b/run_service.sh
@@ -1027,13 +1027,17 @@ if [ "$local_service_hash" != "$remote_service_hash" ] || [ "$on_chain_agent_id"
     echo ""
 
     response="y"
-    if [ "${USE_STAKING}" = true ] && [ "$ATTENDED" = true ]; then
+    if [ "${USE_STAKING}" = true ]; then
       echo "If your service is in a staking program, updating your on-chain service requires that it is first unstaked."
       echo "Unstaking your service will retrieve the accrued staking rewards."
       echo ""
-      echo "Do you want to continue updating your service? (yes/no)"
-      read -r response
-      echo ""
+      if [ "$ATTENDED" = true ]; then
+        echo "Do you want to continue updating your service? (yes/no)"
+        read -r response
+        echo ""
+      else
+        response="n"
+      fi
     fi
 
     if [[ ! "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then


### PR DESCRIPTION
Avoid unstaking happening automatically when the image hash changes (in unattended mode)