### PR TITLE
chore: redirect to new quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+<h1 align="center">
+<b> 🚨 WARNING: Repository is deprecated 🚨</b>
+</h1>
+
+<p align="center">
+This repository has been deprecated and will not be supported until further notice.
+<br>
+If you are using it for the first time, please use <a href="https://github.com/valory-xyz/quickstart/">the new Quickstart</a>.
+<!-- <br>
+If you are already running agents using this quickstart, please use the <a href="https://github.com/valory-xyz/quickstart/tree/main/scripts/predict_trader#migrate-from-trader-quickstart">Migration Script</a> to migrate your agents to the new Quickstart. -->
+</p>
+
 # trader-quickstart
 
 A quickstart for the trader agent for AI prediction markets on Gnosis at https://github.com/valory-xyz/trader

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <h1 align="center">
-<b> 🚨 WARNING: Repository is deprecated 🚨</b>
+<b> 🚨 WARNING: Repository will be deprecated soon 🚨</b>
 </h1>
 
 <p align="center">
-This repository has been deprecated and will not be supported until further notice.
+This repository will soon be deprecated and further maintenance is not guaranteed moving forward.
 <br>
 If you are using it for the first time, please use <a href="https://github.com/valory-xyz/quickstart/">the new Quickstart</a>.
 <!-- <br>


### PR DESCRIPTION
~Please merge this PR only after merging https://github.com/valory-xyz/quickstart/pull/31 to `main`, because the link to the migration script is made available from `main`.~
The migration script update will be made later when it's ready, we can redirect the new users for now.