### PR TITLE
Fix: Terminate with password

### DIFF
--- a/terminate_on_chain_service.sh
+++ b/terminate_on_chain_service.sh
@@ -177,7 +177,7 @@ cd trader
 validate_password
 
 # Unstake if applicable
-poetry run python "../scripts/staking.py" "$service_id" "$CUSTOM_SERVICE_REGISTRY_ADDRESS" "$CUSTOM_STAKING_ADDRESS" "../$operator_pkey_path" "$rpc" "$unstake";
+poetry run python "../scripts/staking.py" "$service_id" "$CUSTOM_SERVICE_REGISTRY_ADDRESS" "$CUSTOM_STAKING_ADDRESS" "../$operator_pkey_path" "$rpc" "$unstake" $password_argument;
 
 service_safe_address=$(cat "../$service_safe_address_path")
 current_safe_owners=$(poetry run python "../scripts/get_safe_owners.py" "$service_safe_address" "../$agent_pkey_path" "$rpc" $password_argument | awk '{gsub(/"/, "\047", $0); print $0}')


### PR DESCRIPTION
This fixes a bug reported by a user. The terminate script was failing if the quickstart had a password.